### PR TITLE
Add RPC endpoint health monitoring and failover

### DIFF
--- a/src/aloran_treasury/app.py
+++ b/src/aloran_treasury/app.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import sys
 from typing import Iterable, List, Optional
 
-from PySide6.QtGui import QColor, QPalette
+from PySide6.QtGui import QCloseEvent, QColor, QPalette
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -34,6 +34,7 @@ from PySide6.QtWidgets import (
 )
 
 from .theme import BACKGROUND, FONT_FAMILY, FONT_SIZE, PALETTE, SURFACE, SURFACE_ALT, TEXT_MUTED, TEXT_PRIMARY, muted
+from .network_monitor import NetworkMonitor
 from .wallet import (
     LAMPORTS_PER_SOL,
     NETWORKS,
@@ -279,12 +280,16 @@ class TreasuryConsole(QWidget):
     def __init__(self) -> None:
         super().__init__()
         self.wallet_state = WalletState()
+        self.wallet_state.subscribe_endpoint_updates(self._update_network_chip)
         self.wallet_controller = WalletController(self.wallet_state)
         self.setWindowTitle("Aloran Treasury Console (Prototype)")
         self.setMinimumSize(720, 720)
         self.failed_transfers: list[tuple[TransferRequest, Optional[float]]] = []
         self._build()
         self._refresh_ata_table()
+        self.network_monitor = NetworkMonitor(self.wallet_state, interval_seconds=20, parent=self)
+        self.network_monitor.start()
+        self._update_network_chip()
 
     def _build(self) -> None:
         layout = QVBoxLayout()
@@ -308,10 +313,6 @@ class TreasuryConsole(QWidget):
         combo.currentTextChanged.connect(self._handle_network_changed)
 
         chip = QLabel(self._network_chip_text())
-        chip.setStyleSheet(
-            f"padding: 6px 10px; background-color: {PALETTE['dark_blue']}; "
-            f"border-radius: 12px; font-weight: 600;"
-        )
         chip.setObjectName("networkChip")
         self.network_chip = chip
 
@@ -474,7 +475,36 @@ class TreasuryConsole(QWidget):
         return column
 
     def _network_chip_text(self) -> str:
-        return f"{self.wallet_state.network} · preview"
+        status = self.wallet_state.current_endpoint_status()
+        latency = (
+            f"{status.last_latency_ms:.0f} ms" if status.last_latency_ms is not None else "—"
+        )
+        if status.last_checked is None:
+            state = "Checking…"
+        elif status.healthy:
+            state = "Healthy"
+        else:
+            state = "Unhealthy"
+        return f"{self.wallet_state.network} · {status.label} ({latency}) · {state}"
+
+    def _network_chip_style(self) -> str:
+        status = self.wallet_state.current_endpoint_status()
+        if status.last_checked is None:
+            background = PALETTE["medium_blue"]
+        elif status.healthy:
+            background = PALETTE["teal"]
+        else:
+            background = PALETTE["dark_purple"]
+        return (
+            f"padding: 6px 10px; background-color: {background}; "
+            f"border-radius: 12px; font-weight: 600;"
+        )
+
+    def _update_network_chip(self) -> None:
+        if not hasattr(self, "network_chip"):
+            return
+        self.network_chip.setText(self._network_chip_text())
+        self.network_chip.setStyleSheet(self._network_chip_style())
 
     def _public_key_line(self) -> str:
         return (
@@ -661,13 +691,20 @@ class TreasuryConsole(QWidget):
         for transfer, rate in pending:
             self._process_transfers([transfer], rate)
 
+    def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802 - Qt override
+        if hasattr(self, "network_monitor"):
+            self.network_monitor.stop()
+        super().closeEvent(event)
+
     def _handle_network_changed(self, network: str) -> None:
         self.wallet_state.switch_network(network)
         self.wallet_state.sol_balance = None
-        self.network_chip.setText(self._network_chip_text())
+        self._update_network_chip()
         self.wallet_status.setText(self.wallet_state.status_line())
         self.balance_label.setText(self._balance_line())
         self._enqueue_action(f"Switched to {network}")
+        if hasattr(self, "network_monitor"):
+            self.network_monitor.force_poll()
         self._refresh_ata_table()
 
     def _toggle_lock(self) -> None:

--- a/src/aloran_treasury/network_monitor.py
+++ b/src/aloran_treasury/network_monitor.py
@@ -1,0 +1,69 @@
+"""Background RPC endpoint health monitoring."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from PySide6.QtCore import QObject, QTimer
+from solana.rpc.api import Client
+
+from .wallet import WalletState
+
+
+class NetworkMonitor(QObject):
+    """Periodically ping RPC endpoints for the active cluster."""
+
+    def __init__(
+        self,
+        wallet_state: WalletState,
+        interval_seconds: int = 30,
+        parent: Optional[QObject] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.wallet_state = wallet_state
+        interval_ms = max(15, min(interval_seconds, 60)) * 1000
+        self._timer = QTimer(self)
+        self._timer.setInterval(interval_ms)
+        self._timer.timeout.connect(self._poll)  # type: ignore[arg-type]
+
+    def start(self) -> None:
+        """Start polling and perform an immediate check."""
+
+        self._poll()
+        self._timer.start()
+
+    def stop(self) -> None:
+        """Halt polling."""
+
+        self._timer.stop()
+
+    def force_poll(self) -> None:
+        """Trigger a manual health check."""
+
+        self._poll()
+
+    def _poll(self) -> None:
+        network = self.wallet_state.network
+        endpoints = self.wallet_state.endpoint_statuses_for_network(network)
+        for endpoint in endpoints:
+            healthy, latency_ms = self._ping_endpoint(endpoint.url)
+            self.wallet_state.record_endpoint_check(
+                endpoint.url, healthy, latency_ms, time.time(), network
+            )
+
+        current = self.wallet_state.current_endpoint_status(network)
+        if current.healthy is False:
+            self.wallet_state.advance_to_next_endpoint(network)
+
+    def _ping_endpoint(self, url: str) -> tuple[bool, Optional[float]]:
+        start = time.perf_counter()
+        try:
+            client = Client(url)
+            response = client.get_health()
+            latency_ms = (time.perf_counter() - start) * 1000
+            value = getattr(response, "value", None)
+            healthy = value in {"ok", "healthy", True, None}
+            return healthy, latency_ms
+        except Exception:
+            return False, None


### PR DESCRIPTION
## Summary
- add endpoint health tracking, failover, and rotation for wallet RPC operations
- introduce a background network monitor that pings cluster endpoints and updates state
- surface endpoint health and latency in the network selector chip with lifecycle-aware polling

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c9a05d15c8323b40455a858128572)