### PR TITLE
Add lock manager with keystore unlock and timer

### DIFF
--- a/src/aloran_treasury/app.py
+++ b/src/aloran_treasury/app.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import sys
 from typing import Iterable, List, Optional
 
-from PySide6.QtCore import QUrl
+from PySide6.QtCore import QEvent, QUrl
 from PySide6.QtGui import QColor, QDesktopServices, QPalette
 from PySide6.QtWidgets import (
     QApplication,
@@ -38,6 +38,7 @@ from PySide6.QtWidgets import (
 from .components import MintSettingsPanel
 from .theme import BACKGROUND, FONT_FAMILY, FONT_SIZE, PALETTE, SURFACE, SURFACE_ALT, TEXT_MUTED, TEXT_PRIMARY, muted
 from .network_monitor import NetworkMonitor
+from .lock_manager import LockManager
 from .wallet import (
     LAMPORTS_PER_SOL,
     NETWORKS,
@@ -283,15 +284,20 @@ class TransferDialog(QDialog):
 class TreasuryConsole(QWidget):
     def __init__(self) -> None:
         super().__init__()
+        self.lock_manager = LockManager(Path.home() / ".aloran_treasury" / "keystore.json", inactivity_seconds=300)
+        self.installEventFilter(self)
         self.wallet_state = WalletState()
         self.wallet_state.subscribe_endpoint_updates(self._update_network_chip)
-        self.wallet_controller = WalletController(self.wallet_state)
+        self.wallet_controller = WalletController(self.wallet_state, lock_manager=self.lock_manager)
         self.setWindowTitle("Aloran Treasury Console (Prototype)")
         self.setMinimumSize(720, 720)
         self.failed_transfers: list[tuple[TransferRequest, Optional[float]]] = []
         self.history_entries: list[TransactionHistoryEntry] = []
         self.history_cursor: Optional[str] = None
+        self.lock_manager.subscribe_unlock(self._on_unlock_event)
+        self.lock_manager.subscribe_lock(self._on_lock_event)
         self._build()
+        self._bootstrap_keystore()
         self._refresh_ata_table()
         self.network_monitor = NetworkMonitor(self.wallet_state, interval_seconds=20, parent=self)
         self.network_monitor.start()
@@ -898,11 +904,11 @@ class TreasuryConsole(QWidget):
         self._refresh_ata_table()
 
     def _toggle_lock(self) -> None:
-        self.wallet_state.toggle_lock()
-        self.wallet_status.setText(self.wallet_state.status_line())
-        self.lock_button.setText("Unlock" if self.wallet_state.locked else "Lock")
-        state = "Locked" if self.wallet_state.locked else "Unlocked"
-        self._enqueue_action(f"Wallet {state.lower()}")
+        if self.lock_manager.locked:
+            self._prompt_unlock()
+            return
+
+        self.lock_manager.lock("manual")
 
     def _generate_keypair(self) -> None:
         secret = self.wallet_controller.generate_ephemeral()
@@ -961,6 +967,7 @@ class TreasuryConsole(QWidget):
         self._enqueue_action("Balance refreshed")
 
     def _enqueue_action(self, description: str) -> None:
+        self.lock_manager.register_activity()
         self.wallet_state.enqueue_action(description)
         item = QListWidgetItem(description)
         self.activity_list.addItem(item)
@@ -970,6 +977,48 @@ class TreasuryConsole(QWidget):
 
     def _show_message(self, title: str, message: str) -> None:
         QMessageBox.information(self, title, message)
+
+    def _on_unlock_event(self, _: object) -> None:
+        self.wallet_status.setText(self.wallet_state.status_line())
+        self.lock_button.setText("Lock")
+
+    def _on_lock_event(self) -> None:
+        self.wallet_status.setText(self.wallet_state.status_line())
+        self.lock_button.setText("Unlock")
+
+    def _bootstrap_keystore(self) -> None:
+        if self.lock_manager.has_keystore:
+            self.wallet_state.locked = True
+            self.wallet_status.setText(self.wallet_state.status_line())
+            self._prompt_unlock()
+        else:
+            self.wallet_status.setText(self.wallet_state.status_line())
+
+    def _prompt_unlock(self) -> None:
+        passphrase, ok = QInputDialog.getText(
+            self,
+            "Unlock wallet",
+            "Enter passphrase for your keystore",
+            QLineEdit.EchoMode.Password,
+        )
+        if not ok or not passphrase:
+            return
+        try:
+            self.lock_manager.unlock(passphrase)
+            self.lock_manager.register_activity()
+        except ValueError as exc:  # noqa: BLE001 - surface decryption failures
+            self._show_error("Unlock failed", str(exc))
+        except RuntimeError as exc:
+            self._show_error("No keystore", str(exc))
+
+    def eventFilter(self, obj, event):  # type: ignore[override]
+        if event.type() in {
+            QEvent.Type.MouseButtonPress,
+            QEvent.Type.KeyPress,
+            QEvent.Type.Wheel,
+        }:
+            self.lock_manager.register_activity()
+        return super().eventFilter(obj, event)
 
 
 def build_window() -> QWidget:

--- a/src/aloran_treasury/lock_manager.py
+++ b/src/aloran_treasury/lock_manager.py
@@ -1,0 +1,178 @@
+"""Manage wallet lock state, in-memory keypair hydration, and inactivity timeouts."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from solders.keypair import Keypair
+
+
+def _xor_bytes(left: bytes, right: bytes) -> bytes:
+    """XOR two byte strings, truncating to the shorter length."""
+
+    return bytes(a ^ b for a, b in zip(left, right))
+
+
+def _derive_key(passphrase: str, salt: bytes, length: int = 64) -> bytes:
+    """Derive a deterministic byte key from the provided passphrase and salt."""
+
+    # hashlib is intentionally imported lazily to avoid heavy imports at module load time.
+    import hashlib
+
+    return hashlib.pbkdf2_hmac("sha256", passphrase.encode("utf-8"), salt, 200_000, dklen=length)
+
+
+@dataclass
+class LockState:
+    """Simple DTO describing the current lock posture."""
+
+    locked: bool = True
+    timer_handle: Optional[threading.Timer] = None
+
+
+class LockManager:
+    """Centralized manager for lock/unlock events and keystore hydration."""
+
+    def __init__(
+        self,
+        keystore_path: Path,
+        inactivity_seconds: int = 300,
+    ) -> None:
+        self.keystore_path = keystore_path
+        self.inactivity_seconds = inactivity_seconds
+        self.state = LockState()
+        self._keypair: Optional[Keypair] = None
+        self._lock_listeners: list[Callable[[], None]] = []
+        self._unlock_listeners: list[Callable[[Keypair], None]] = []
+        self._keystore_metadata: Optional[dict] = None
+
+        self._load_keystore()
+
+    @property
+    def keypair(self) -> Optional[Keypair]:
+        """Return the decrypted keypair currently held in memory, if any."""
+
+        return self._keypair
+
+    @property
+    def locked(self) -> bool:
+        return self.state.locked
+
+    @property
+    def has_keystore(self) -> bool:
+        return self._keystore_metadata is not None
+
+    def _load_keystore(self) -> None:
+        if not self.keystore_path.exists():
+            return
+
+        try:
+            self._keystore_metadata = json.loads(self.keystore_path.read_text())
+        except json.JSONDecodeError:
+            # Malformed keystore should be treated as absent to avoid accidental unlocks.
+            self._keystore_metadata = None
+
+    def subscribe_lock(self, listener: Callable[[], None]) -> None:
+        self._lock_listeners.append(listener)
+
+    def subscribe_unlock(self, listener: Callable[[Keypair], None]) -> None:
+        self._unlock_listeners.append(listener)
+
+    def register_activity(self) -> None:
+        """Reset the inactivity timer upon user interaction."""
+
+        if self.locked:
+            return
+        self._start_timer()
+
+    def persist_keystore(self, passphrase: str, keypair: Keypair) -> None:
+        """Persist the provided keypair encrypted with the given passphrase."""
+
+        salt = Keypair().to_bytes()[:16]
+        derived_key = _derive_key(passphrase, salt)
+        ciphertext = _xor_bytes(keypair.to_bytes(), derived_key)
+        metadata = {
+            "salt": base64.b64encode(salt).decode("utf-8"),
+            "ciphertext": base64.b64encode(ciphertext).decode("utf-8"),
+            "public_key": str(keypair.pubkey()),
+            "created": time.time(),
+        }
+        self.keystore_path.parent.mkdir(parents=True, exist_ok=True)
+        self.keystore_path.write_text(json.dumps(metadata))
+        self._keystore_metadata = metadata
+
+    def unlock(self, passphrase: str) -> Keypair:
+        """Decrypt the keystore and hydrate the in-memory keypair."""
+
+        if self._keystore_metadata is None:
+            raise RuntimeError("No keystore metadata available")
+
+        salt_b64 = self._keystore_metadata.get("salt")
+        ciphertext_b64 = self._keystore_metadata.get("ciphertext")
+        if not salt_b64 or not ciphertext_b64:
+            raise ValueError("Incomplete keystore metadata")
+
+        salt = base64.b64decode(salt_b64)
+        ciphertext = base64.b64decode(ciphertext_b64)
+        derived_key = _derive_key(passphrase, salt, length=len(ciphertext))
+        plaintext = _xor_bytes(ciphertext, derived_key)
+
+        try:
+            keypair = Keypair.from_bytes(plaintext)
+        except Exception as exc:  # noqa: BLE001 - conversion failure signals bad passphrase
+            raise ValueError("Failed to decrypt keystore with provided passphrase") from exc
+
+        self._set_unlocked(keypair)
+        return keypair
+
+    def unlock_with_keypair(self, keypair: Keypair) -> None:
+        """Assume an already decrypted keypair and mark the session unlocked."""
+
+        self._set_unlocked(keypair)
+
+    def _set_unlocked(self, keypair: Keypair) -> None:
+        self._keypair = keypair
+        self.state.locked = False
+        self._start_timer()
+        for listener in self._unlock_listeners:
+            listener(keypair)
+
+    def lock(self, reason: str = "manual") -> None:
+        """Explicitly lock the session and clear in-memory secrets."""
+
+        if self.state.timer_handle:
+            self.state.timer_handle.cancel()
+            self.state.timer_handle = None
+        self._keypair = None
+        self.state.locked = True
+        for listener in self._lock_listeners:
+            listener()
+
+    def _start_timer(self) -> None:
+        if self.inactivity_seconds <= 0:
+            return
+
+        if self.state.timer_handle:
+            self.state.timer_handle.cancel()
+
+        timer = threading.Timer(self.inactivity_seconds, self._expire_session)
+        timer.daemon = True
+        timer.start()
+        self.state.timer_handle = timer
+
+    def _expire_session(self) -> None:
+        self.lock("timeout")
+
+    def shutdown(self) -> None:
+        """Clean up resources, primarily timers used in tests."""
+
+        if self.state.timer_handle:
+            self.state.timer_handle.cancel()
+            self.state.timer_handle = None
+

--- a/src/aloran_treasury/wallet.py
+++ b/src/aloran_treasury/wallet.py
@@ -11,6 +11,8 @@ from solana.rpc.api import Client
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 
+from .lock_manager import LockManager
+
 Network = Literal["Mainnet", "Testnet", "Devnet"]
 TokenProgram = Literal["Token-2022", "Token"]
 NETWORKS: list[Network] = ["Mainnet", "Testnet", "Devnet"]
@@ -520,10 +522,15 @@ def set_interest_rate(
 class WalletController:
     """Manage the active keypair and lightweight RPC queries."""
 
-    def __init__(self, state: WalletState) -> None:
+    def __init__(self, state: WalletState, lock_manager: Optional[LockManager] = None) -> None:
         self.state = state
+        self.lock_manager = lock_manager
         self._keypair: Optional[Keypair] = None
         self.endpoints: dict[Network, list[EndpointStatus]] = _default_endpoint_matrix()
+
+        if self.lock_manager:
+            self.lock_manager.subscribe_unlock(self._receive_unlock)
+            self.lock_manager.subscribe_lock(self._receive_lock)
 
     def set_token_program(self, token_program: TokenProgram) -> None:
         """Update the active token program preference."""
@@ -1041,9 +1048,25 @@ class WalletController:
         return normalized
 
     def _apply_keypair(self, keypair: Keypair) -> None:
+        if self.lock_manager:
+            self.lock_manager.unlock_with_keypair(keypair)
+            return
+
         self._keypair = keypair
         self.state.public_key = str(keypair.pubkey())
         self.state.locked = False
+        self.state.sol_balance = None
+
+    def _receive_unlock(self, keypair: Keypair) -> None:
+        self._keypair = keypair
+        self.state.public_key = str(keypair.pubkey())
+        self.state.locked = False
+        self.state.sol_balance = None
+
+    def _receive_lock(self) -> None:
+        self._keypair = None
+        self.state.public_key = None
+        self.state.locked = True
         self.state.sol_balance = None
 
     def select_endpoint(self, network: Optional[Network] = None) -> EndpointStatus:

--- a/tests/test_lock_manager.py
+++ b/tests/test_lock_manager.py
@@ -1,0 +1,61 @@
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from aloran_treasury.lock_manager import LockManager
+from solders.keypair import Keypair
+
+
+class LockManagerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = TemporaryDirectory()
+        self.keystore_path = Path(self.temp_dir.name) / "keystore.json"
+        self.manager = LockManager(self.keystore_path, inactivity_seconds=0.2)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        self.temp_dir.cleanup()
+
+    def test_unlock_success_and_failure(self) -> None:
+        keypair = Keypair()
+        self.manager.persist_keystore("correct horse", keypair)
+
+        fresh_manager = LockManager(self.keystore_path, inactivity_seconds=0.2)
+        self.assertTrue(fresh_manager.has_keystore)
+
+        with self.assertRaises(ValueError):
+            fresh_manager.unlock("bad passphrase")
+
+        unlocked = fresh_manager.unlock("correct horse")
+        self.assertFalse(fresh_manager.locked)
+        self.assertEqual(unlocked.pubkey(), keypair.pubkey())
+
+        fresh_manager.shutdown()
+
+    def test_timer_based_relock(self) -> None:
+        keypair = Keypair()
+        self.manager.persist_keystore("timer", keypair)
+        self.manager.unlock("timer")
+        self.assertFalse(self.manager.locked)
+
+        time.sleep(0.4)
+        self.assertTrue(self.manager.locked)
+        self.assertIsNone(self.manager.keypair)
+
+    def test_manual_lock_clears_keypair(self) -> None:
+        keypair = Keypair()
+        self.manager.persist_keystore("manual", keypair)
+        self.manager.unlock("manual")
+        self.assertIsNotNone(self.manager.keypair)
+
+        self.manager.lock("manual")
+        self.assertTrue(self.manager.locked)
+        self.assertIsNone(self.manager.keypair)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a lock manager that loads encrypted keystore metadata, unlocks with a passphrase, and enforces inactivity re-locks
- wire the UI and wallet controller to the centralized lock manager with unlock prompts and activity hooks
- add unit tests covering unlock failure/success paths and auto/manual re-lock behavior

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c9fd63b248323924679dc5c90f738)