### PR TITLE
Add keystore crypto helpers and storage persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "alorancredits",
+  "version": "1.0.0",
+  "description": "Product notes and prototype code for the Aloran Treasury Console prototype.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "ISC"
+}

--- a/src/lib/crypto/keystore.js
+++ b/src/lib/crypto/keystore.js
@@ -1,0 +1,73 @@
+import { webcrypto, scrypt as nodeScrypt, randomBytes as nodeRandomBytes } from 'crypto';
+import { promisify } from 'util';
+
+const cryptoApi = webcrypto;
+const scryptAsync = promisify(nodeScrypt);
+
+export const defaultKdfParams = {
+  N: 2 ** 15,
+  r: 8,
+  p: 1,
+  dkLen: 32,
+};
+
+function encodeBase64(bytes) {
+  return Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
+}
+
+function toUint8(data) {
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+  return data;
+}
+
+async function deriveAesMaterial(passphrase, salt, kdfParams) {
+  const keyBuffer = await scryptAsync(passphrase, salt, kdfParams.dkLen, {
+    cost: kdfParams.N,
+    blockSize: kdfParams.r,
+    parallelization: kdfParams.p,
+    maxmem: 64 * 1024 * 1024,
+  });
+  return new Uint8Array(keyBuffer);
+}
+
+export async function deriveKey(passphrase, salt, kdfParams = defaultKdfParams) {
+  const saltBytes = typeof salt === 'string' ? Buffer.from(salt, 'base64') : salt;
+  const keyMaterial = await deriveAesMaterial(passphrase, saltBytes, kdfParams);
+  return cryptoApi.subtle.importKey('raw', keyMaterial, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+export async function encryptKeystore(data, passphrase, keyType) {
+  const salt = nodeRandomBytes(16);
+  const iv = cryptoApi.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(passphrase, salt, defaultKdfParams);
+  const plaintext = toUint8(data);
+  const ciphertextBuffer = await cryptoApi.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+  return {
+    ciphertext: encodeBase64(ciphertextBuffer),
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    kdfParams: { ...defaultKdfParams },
+    createdAt: new Date().toISOString(),
+    keyType,
+  };
+}
+
+export async function decryptKeystore(record, passphrase) {
+  const key = await deriveKey(passphrase, Buffer.from(record.salt, 'base64'), record.kdfParams);
+  const iv = Buffer.from(record.iv, 'base64');
+  const ciphertext = Buffer.from(record.ciphertext, 'base64');
+  const plaintext = await cryptoApi.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return new Uint8Array(plaintext);
+}
+
+export const keystoreShapeDocumentation = `{
+  ciphertext: string; // base64 AES-GCM ciphertext
+  salt: string;       // base64 salt for scrypt
+  iv: string;         // base64 AES-GCM IV
+  kdfParams: { N: number; r: number; p: number; dkLen: number };
+  createdAt: string;  // ISO timestamp
+  keyType?: string;   // optional descriptor of key material
+}`;

--- a/src/lib/crypto/keystore.ts
+++ b/src/lib/crypto/keystore.ts
@@ -1,0 +1,111 @@
+import { webcrypto, scrypt as nodeScrypt, randomBytes as nodeRandomBytes } from 'crypto';
+import { promisify } from 'util';
+
+const cryptoApi = webcrypto;
+const scryptAsync = promisify(nodeScrypt);
+
+export type KdfParams = {
+  /** CPU/memory cost parameter (N). */
+  N: number;
+  /** Block size parameter (r). */
+  r: number;
+  /** Parallelization parameter (p). */
+  p: number;
+  /** Length in bytes of the derived key. */
+  dkLen: number;
+};
+
+export type KeystoreRecord = {
+  /** Base64-encoded AES-GCM ciphertext. */
+  ciphertext: string;
+  /** Base64-encoded salt used for the KDF. */
+  salt: string;
+  /** Base64-encoded AES-GCM IV. */
+  iv: string;
+  /** KDF parameters used during key derivation. */
+  kdfParams: KdfParams;
+  /** ISO8601 timestamp indicating when the keystore was created. */
+  createdAt: string;
+  /** Optional descriptive key type (e.g., "ed25519"). */
+  keyType?: string;
+};
+
+export const defaultKdfParams: KdfParams = {
+  N: 2 ** 15,
+  r: 8,
+  p: 1,
+  dkLen: 32,
+};
+
+function encodeBase64(bytes: ArrayBuffer | Uint8Array): string {
+  return Buffer.from(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)).toString('base64');
+}
+
+function toUint8(data: Uint8Array | string): Uint8Array {
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+  return data;
+}
+
+async function deriveAesMaterial(passphrase: string, salt: Uint8Array, kdfParams: KdfParams): Promise<Uint8Array> {
+  const keyBuffer = (await scryptAsync(passphrase, salt, kdfParams.dkLen, {
+    cost: kdfParams.N,
+    blockSize: kdfParams.r,
+    parallelization: kdfParams.p,
+    maxmem: 64 * 1024 * 1024,
+  })) as Buffer;
+  return new Uint8Array(keyBuffer);
+}
+
+export async function deriveKey(
+  passphrase: string,
+  salt: Uint8Array | string,
+  kdfParams: KdfParams = defaultKdfParams,
+): Promise<CryptoKey> {
+  const saltBytes = typeof salt === 'string' ? Buffer.from(salt, 'base64') : salt;
+  const keyMaterial = await deriveAesMaterial(passphrase, saltBytes, kdfParams);
+  return cryptoApi.subtle.importKey('raw', keyMaterial, 'AES-GCM', false, ['encrypt', 'decrypt']);
+}
+
+export async function encryptKeystore(
+  data: Uint8Array | string,
+  passphrase: string,
+  keyType?: string,
+): Promise<KeystoreRecord> {
+  const salt = nodeRandomBytes(16);
+  const iv = cryptoApi.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(passphrase, salt, defaultKdfParams);
+  const plaintext = toUint8(data);
+  const ciphertextBuffer = await cryptoApi.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+  return {
+    ciphertext: encodeBase64(ciphertextBuffer),
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    kdfParams: { ...defaultKdfParams },
+    createdAt: new Date().toISOString(),
+    keyType,
+  };
+}
+
+export async function decryptKeystore(record: KeystoreRecord, passphrase: string): Promise<Uint8Array> {
+  const key = await deriveKey(passphrase, Buffer.from(record.salt, 'base64'), record.kdfParams);
+  const iv = Buffer.from(record.iv, 'base64');
+  const ciphertext = Buffer.from(record.ciphertext, 'base64');
+  const plaintext = await cryptoApi.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return new Uint8Array(plaintext);
+}
+
+/**
+ * JSON shape stored on disk or in browser storage:
+ * {
+ *   ciphertext: string; // base64 AES-GCM ciphertext
+ *   salt: string;       // base64 salt for scrypt
+ *   iv: string;         // base64 AES-GCM IV
+ *   kdfParams: { N: number; r: number; p: number; dkLen: number };
+ *   createdAt: string;  // ISO timestamp
+ *   keyType?: string;   // optional descriptor of key material
+ * }
+ */
+export type Keystore = KeystoreRecord;

--- a/src/storage/keystore.js
+++ b/src/storage/keystore.js
@@ -1,0 +1,42 @@
+const KEYSTORE_KEY = 'aloran.keystore';
+let inMemoryFallback = null;
+
+function resolveStorage() {
+  if (typeof globalThis !== 'undefined' && 'localStorage' in globalThis) {
+    return globalThis.localStorage;
+  }
+  return null;
+}
+
+export function saveKeystore(record) {
+  const { ciphertext, salt, iv } = record;
+  if (!ciphertext || !salt || !iv) {
+    throw new Error('Keystore record must include ciphertext, salt, and iv');
+  }
+
+  const payload = JSON.stringify(record);
+  const storage = resolveStorage();
+  if (storage) {
+    storage.setItem(KEYSTORE_KEY, payload);
+  } else {
+    inMemoryFallback = record;
+  }
+}
+
+export function loadKeystore() {
+  const storage = resolveStorage();
+  const storedValue = storage ? storage.getItem(KEYSTORE_KEY) : null;
+
+  if (storedValue) {
+    return JSON.parse(storedValue);
+  }
+  return inMemoryFallback;
+}
+
+export function clearKeystore() {
+  const storage = resolveStorage();
+  if (storage) {
+    storage.removeItem(KEYSTORE_KEY);
+  }
+  inMemoryFallback = null;
+}

--- a/src/storage/keystore.ts
+++ b/src/storage/keystore.ts
@@ -1,0 +1,50 @@
+import type { KeystoreRecord } from '../lib/crypto/keystore.js';
+
+const KEYSTORE_KEY = 'aloran.keystore';
+let inMemoryFallback: KeystoreRecord | null = null;
+
+type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function resolveStorage(): StorageLike | null {
+  if (typeof globalThis !== 'undefined' && 'localStorage' in globalThis) {
+    return (globalThis as unknown as { localStorage: StorageLike }).localStorage;
+  }
+  return null;
+}
+
+export function saveKeystore(record: KeystoreRecord): void {
+  const { ciphertext, salt, iv } = record;
+  if (!ciphertext || !salt || !iv) {
+    throw new Error('Keystore record must include ciphertext, salt, and iv');
+  }
+
+  const payload = JSON.stringify(record);
+  const storage = resolveStorage();
+  if (storage) {
+    storage.setItem(KEYSTORE_KEY, payload);
+  } else {
+    inMemoryFallback = record;
+  }
+}
+
+export function loadKeystore(): KeystoreRecord | null {
+  const storage = resolveStorage();
+  const storedValue = storage ? storage.getItem(KEYSTORE_KEY) : null;
+
+  if (storedValue) {
+    return JSON.parse(storedValue) as KeystoreRecord;
+  }
+  return inMemoryFallback;
+}
+
+export function clearKeystore(): void {
+  const storage = resolveStorage();
+  if (storage) {
+    storage.removeItem(KEYSTORE_KEY);
+  }
+  inMemoryFallback = null;
+}

--- a/tests/keystore.test.js
+++ b/tests/keystore.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { decryptKeystore, encryptKeystore } from '../src/lib/crypto/keystore.js';
+
+const decoder = new TextDecoder();
+
+test('encrypts and decrypts keystore data with matching passphrase', async () => {
+  const secret = 'super-secret-data';
+  const record = await encryptKeystore(secret, 'correct horse battery staple', 'ed25519');
+  const plaintext = await decryptKeystore(record, 'correct horse battery staple');
+
+  assert.strictEqual(decoder.decode(plaintext), secret);
+  assert.ok(record.createdAt);
+  assert.strictEqual(record.keyType, 'ed25519');
+  assert.ok(record.kdfParams.N);
+});
+
+test('rejects decryption with an incorrect passphrase', async () => {
+  const record = await encryptKeystore('lock-this', 'right-password');
+
+  await assert.rejects(() => decryptKeystore(record, 'wrong-password'));
+});
+
+test('detects tampering of ciphertext or iv', async () => {
+  const record = await encryptKeystore('immutable', 'lock');
+  const ciphertextBytes = Buffer.from(record.ciphertext, 'base64');
+  ciphertextBytes[0] = ciphertextBytes[0] ^ 0b00000001;
+
+  const tampered = { ...record, ciphertext: ciphertextBytes.toString('base64') };
+  await assert.rejects(() => decryptKeystore(tampered, 'lock'));
+});


### PR DESCRIPTION
## Summary
- add AES-GCM keystore crypto helper with scrypt-based key derivation and metadata
- add storage helpers for persisting a single encrypted keystore record without plaintext leakage
- cover keystore operations with node tests for round-trip, wrong passphrase, and tamper detection

## Testing
- node --test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ca04b160c83238d4ec047df2662b3)